### PR TITLE
Buildraidmsg

### DIFF
--- a/src/commands/buildraidmsg.js
+++ b/src/commands/buildraidmsg.js
@@ -1,0 +1,29 @@
+const { ClientRequest } = require('http');
+const { client } = require('tmi.js');
+const database = require('../database');
+
+module.exports = function(context) {
+  const { client, target } = context;
+
+  // data validation
+  if (!context?.['display-name'] ||
+      !context?.['user-id']) {
+    console.log('validation failed');
+    return;
+  }
+  
+  // return if not mod
+  if (!isMod(user.id)) {
+    client.say(target, `Sorry, only mods can build raid messages`);
+    return;
+  }
+  
+  // get msg
+  const msg = context.variables.join(' ') + ' ';
+  
+  // repeat msg to make raidmsg
+  const raidmsg = msg.repeat(6);
+  
+  // print result
+  client.say(target, `${raidmsg}`);
+}

--- a/src/commands/index.js
+++ b/src/commands/index.js
@@ -1,4 +1,5 @@
 module.exports = {
+  '!buildraidmsg': require('./buildraidmsg'),
   '!give': require('./give'),
   '!leaderboard': require('./leaderboard'),
   '!pawggers': require('./pawggers'),


### PR DESCRIPTION
New command that allows mods+ to build raid msgs. User specifies a string, bot returns that string repeated 6 times.